### PR TITLE
chore: add course code for the first year of triennale (`E3102Q`)

### DIFF
--- a/models/course.py
+++ b/models/course.py
@@ -2,4 +2,5 @@ from enum import Enum
 
 class Course(str, Enum):
     informatica_triennale = 'E3101Q'
+    informatica_triennale_primo = 'E3102Q'
     informatica_magistrale = 'F1801Q'


### PR DESCRIPTION
this should fix the following error and the issue reported in #1:
```json
{
  "detail": [
    {
      "type": "enum",
      "loc": [
        "path",
        "corso"
      ],
      "msg": "Input should be 'E3101Q' or 'F1801Q'",
      "input": "E3102Q",
      "ctx": {
        "expected": "'E3101Q' or 'F1801Q'"
      }
    }
  ]
}
```